### PR TITLE
Update unique constraint and table names.

### DIFF
--- a/pipeline/schema.sql
+++ b/pipeline/schema.sql
@@ -3,18 +3,18 @@
 DROP TABLE IF EXISTS sensor_reading;
 DROP TABLE IF EXISTS botanist_assignment;
 DROP TABLE IF EXISTS plant;
-DROP TABLE IF EXISTS origin_location;
+DROP TABLE IF EXISTS origin;
 DROP TABLE IF EXISTS botanist;
-DROP TABLE IF EXISTS country_origin;
+DROP TABLE IF EXISTS country;
 
 -- Longest official country name in English is 56 characters.
-CREATE TABLE country_origin (
+CREATE TABLE country (
     country_id TINYINT IDENTITY(1,1),
     country_name VARCHAR(60) NOT NULL,
     PRIMARY KEY (country_id)
 );
 
-CREATE TABLE origin_location (
+CREATE TABLE origin (
     origin_id SMALLINT IDENTITY(1,1),
     latitude DECIMAL(6, 4) NOT NULL,
     longitude DECIMAL(7, 4) NOT NULL,
@@ -22,18 +22,18 @@ CREATE TABLE origin_location (
     country_id TINYINT NOT NULL,
     PRIMARY KEY (origin_id),
     FOREIGN KEY (country_id)
-        REFERENCES country_origin(country_id),
+        REFERENCES country(country_id),
 );
 
 CREATE TABLE plant (
     plant_id SMALLINT IDENTITY(1,1),
-    plant_name VARCHAR(40) UNIQUE NOT NULL,
+    plant_name VARCHAR(40) NOT NULL,
     origin_id SMALLINT NOT NULL,
     scientific_name VARCHAR(40),
     image_link VARCHAR(255),
     PRIMARY KEY (plant_id),
     FOREIGN KEY (origin_id)
-        REFERENCES origin_location(origin_id)
+        REFERENCES origin(origin_id)
 );
 
 CREATE TABLE sensor_reading (


### PR DESCRIPTION
Removed the unique constraint for `plant_name` in the `plant` table and changed `country_origin` and `origin_location` table names to `country` and `origin`, updating foreign keys and drop table commands to match these new names.